### PR TITLE
fix: sample_name_regex default string

### DIFF
--- a/workflow/rules/filter_vcf.smk
+++ b/workflow/rules/filter_vcf.smk
@@ -12,7 +12,7 @@ rule filter_vcf:
     output:
         vcf=temp("{file}.filter.{tag}.vcf"),
     params:
-        sample_name_regex=config.get("filter_vcf", {}).get("sample_name_regex", "^([A-Za-z0-9-]+_[RT]\{1\})$"),
+        sample_name_regex=config.get("filter_vcf", {}).get("sample_name_regex", "^([A-Za-z0-9-]+_[RT])$"),
         filter_config=lambda wildcards: config["filter_vcf"][wildcards.tag],
     log:
         "{file}.filter.{tag}.log",


### PR DESCRIPTION
When running filter_vcf.py with a matched vcf, the default regex does not remove the backslash in `\{` for the python evaluation and tries to find a literal match instead. By removing the `\{1\}`-part re.search finds the tumor sample if named by hydra-genetic standards.
