### PR TITLE
fix: Correct reading VEP header from vcf

### DIFF
--- a/workflow/scripts/filter_vcf.py
+++ b/workflow/scripts/filter_vcf.py
@@ -366,8 +366,8 @@ def filter_variants(sample_name_regex, in_vcf, out_vcf, filter_yaml_file):
         if record.type == "INFO":
             if record['ID'] == "CSQ":
                 log.info(" -- found vep information: {}".format(in_vcf))
-                log.debug(" -- -- {}".format(record['Description'].split("Format: ")[1].split("|")))
-                vep_fields = {v: c for c, v in enumerate(record['Description'].split("Format: ")[1].split("|"))}
+                log.debug(" -- -- {}".format(record['Description'].split("Format: ")[1].split('">')[0].split("|")))
+                vep_fields = {v: c for c, v in enumerate(record['Description'].split("Format: ")[1].split('">')[0].split("|"))}
                 annotation_extractor["VEP"] = utils.get_annotation_data_vep(vep_fields)
 
     vcf_out = VariantFile(out_vcf, 'w', header=variants.header)


### PR DESCRIPTION
VEP header in vcf-file:

##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|am_class|am_pathogenicity">

Last column will include the "> characters (am_pathogenicity"> in this example).

### This PR:

(If this is a release PR, no need to add following. Leave this part empty)
(Use the following lines to create a PR text body. Make sure to remove all non-relevant one after you're done)
(Repeat each field as many times as necessary)

Added: for new features.
Changed: for changes in existing functionality.
Deprecated: for soon-to-be removed features.
Removed: for now removed features.
Fixed: for any bug fixes.
Security: in case of vulnerabilities.

### Review and tests:
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
- [ ] Module compatibility section in `README.md` is up to date
